### PR TITLE
fix: adds missing dependency errlop

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "caterpillar-filter": "^6.6.0",
     "caterpillar-human": "^6.6.0",
     "cson-parser": "^4.0.4",
+    "errlop": "^3.9.0",
     "fellow": "^6.11.0",
     "get-cli-arg": "^5.5.0",
     "spdx-expression-parse": "^3.0.1",


### PR DESCRIPTION
I have found that I get an error when running `npx projectz compile`.

```
$ npx projectz compile
npx: installed 20 in 2.95s
Cannot find module 'errlop
Require stack:
- /home/elorenz/.npm/_npx/14622/lib/node_modules/projectz/edition-es2019/index.js
- /home/elorenz/.npm/_npx/14622/lib/node_modules/projectz/edition-es2019/bin.js
- /home/elorence/.npm/_npx/14622/lib/node_modules/projectz/bin.js
```

After some analysis I noticed that `errlop` as dependency is missing to work properly.

This PR adds this dependency. I would be happy if you could add this! Thanks for the project!